### PR TITLE
Automatically handle deprecated metric names

### DIFF
--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -15,7 +15,7 @@
 import sys
 
 from dynast.search.search_tactic import LINAS, Evolutionary, RandomSearch
-from dynast.utils import log
+from dynast.utils import check_kwargs_deprecated, log
 
 
 class DyNAS:
@@ -48,6 +48,8 @@ class DyNAS:
             if argument not in kwargs:
                 log.error(f"Missing `--{argument}` parameter.")
                 sys.exit("Missing argument, see log file for info.")
+
+        kwargs = check_kwargs_deprecated(**kwargs)
 
         if len(kwargs['optimization_metrics']) > 3:
             log.error('Number of optimization_metrics is out of range. 1-3 supported.')

--- a/dynast/utils/__init__.py
+++ b/dynast/utils/__init__.py
@@ -178,3 +178,73 @@ def get_remote_file(remote_url: str, model_dir: str, overwrite: bool = False) ->
         f.write(data.content)
 
     return save_path
+
+
+def split_list(lst: list, chunks: int) -> list:
+    """Split list into approximately equally sized chunks.
+
+    If list has less elements than requested chunks, the output list will be padded with empty list items.
+
+    For example:
+    ```
+    >>> split_list([1, 2, 3, 4], 2)
+    [[1, 3], [2, 4]]
+
+    >>> split_list([1, 2, 3, 4], 1)
+    [[1, 2, 3, 4]]
+
+    >>> split_list([1, 2, 3, 4], 5)
+    [[1], [2], [3], [4], []]
+    ```
+    """
+
+    out_lst = [[] for _ in range(chunks)]
+
+    for i in range(len(lst)):
+        out_lst[i % chunks].append(lst[i])
+
+    return out_lst
+
+
+def check_kwargs_deprecated(**kwargs) -> dict:
+    def _deprecated_metric_names(metrics, supernetwork: str):
+        def _rename_deprecated_metrics(update_metrics):
+            for i in range(len(metrics)):
+                try:
+                    old_metric = metrics[i]
+                    metrics[i] = update_metrics[metrics[i]]
+                    _log_deprecated_metric(old_metric, metrics[i])
+                except:
+                    pass
+
+        def _log_deprecated_metric(old_name, new_name):
+            log.warning(
+                'Use of `{old_name}` as a metric has been deprecated. '
+                'Automatically updating to `{new_name}`.'.format(old_name=old_name, new_name=new_name)
+            )
+
+        # General cases
+        update_metrics = {
+            'lat': 'latency',
+            'acc': 'accuracy_top1',
+        }
+        _rename_deprecated_metrics(update_metrics)
+
+        # Special cases
+        # `acc`:
+        #   - Image classification -> `accuracy_top1`
+        #   - Language Translation -> `bleu`
+
+        if supernetwork == 'transformer_lt_wmt_en_de':
+            update_metrics = {
+                'acc': 'bleu',
+                'accuracy_top1': 'bleu',
+            }
+            _rename_deprecated_metrics(update_metrics)
+
+        return metrics
+
+    for key, value in kwargs.items():
+        if key in ['optimization_metrics', 'measurements']:
+            key = _deprecated_metric_names(value, kwargs['supernet'])
+    return kwargs


### PR DESCRIPTION
Add method to automatically handle deprecated metric names.

This will rename metrics from-to:

* `lat` to `latency`
* `acc` to `accuracy_top1` (for image classification)
* `acc` to `bleu` (for language translation)