### PR TITLE
Unpin versions of dependencies used in testing

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,8 @@
-black==22.12.0
-flake8-html==0.4.3
-flake8==6.0.0
-isort==5.10.1
-mypy==0.991
-pytest-cov==4.0.0
-pytest==7.2.0
-tox==4.0.3
+black>=22.12.0
+flake8-html>=0.4.3
+flake8>=6.0.0
+isort>=5.10.1
+mypy>=0.991
+pytest-cov>=4.0.0
+pytest>=7.2.0
+tox>=4.0.3


### PR DESCRIPTION
No real reason for these dependencies to have versions pinned. 
Also, depending on Python version, few of the pinned versions are not available.