### PR TITLE
Update Image Classification Top1 Accuracy Method

### DIFF
--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -20,7 +20,7 @@ def _main(args):
         verbose=args.verbose,
         supernet_ckpt_path=args.supernet_ckpt_path,
         device=args.device,
-        valid_size=args.valid_size,
+        test_size=args.test_size,
         dataloader_workers=args.dataloader_workers,
         distributed=args.distributed,
     )
@@ -68,7 +68,7 @@ def main():
     parser.add_argument('--num_evals', default=250, type=int, help='Total number of evaluations during search.')
     parser.add_argument('--batch_size', default=128, type=int, help='Batch size for latency measurement calculation.')
     parser.add_argument(
-        '--valid_size',
+        '--test_size',
         default=None,
         type=int,
         help='How many batches of data to use when evaluating model\'s accuracy.',

--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -49,7 +49,7 @@ class NASBaseConfig:
         search_algo: str = 'nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -81,7 +81,7 @@ class NASBaseConfig:
         self.supernet_ckpt_path = supernet_ckpt_path
         self.device = device
         self.dataloader_workers = dataloader_workers
-        self.valid_size = valid_size
+        self.test_size = test_size
 
         self.verify_measurement_types()
         self.format_csv_header()
@@ -190,7 +190,7 @@ class NASBaseConfig:
                 batch_size=self.batch_size,
                 device=self.device,
                 dataloader_workers=self.dataloader_workers,
-                valid_size=self.valid_size,
+                test_size=self.test_size,
             )
         elif self.supernet == 'transformer_lt_wmt_en_de':
             self.runner_validate = TransformerLTRunner(
@@ -245,7 +245,7 @@ class LINAS(NASBaseConfig):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -276,7 +276,7 @@ class LINAS(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -346,7 +346,7 @@ class LINAS(NASBaseConfig):
                     dataset_path=self.dataset_path,
                     device=self.device,
                     dataloader_workers=self.dataloader_workers,
-                    valid_size=self.valid_size,
+                    test_size=self.test_size,
                 )
             elif self.supernet == 'transformer_lt_wmt_en_de':
                 runner_predict = TransformerLTRunner(
@@ -494,7 +494,7 @@ class Evolutionary(NASBaseConfig):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path=None,
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         device: str = 'cpu',
         **kwargs,
@@ -513,7 +513,7 @@ class Evolutionary(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -632,7 +632,7 @@ class RandomSearch(NASBaseConfig):
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -650,7 +650,7 @@ class RandomSearch(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -688,7 +688,7 @@ class LINASDistributed(LINAS):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -710,7 +710,7 @@ class LINASDistributed(LINAS):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -782,7 +782,7 @@ class LINASDistributed(LINAS):
                         dataset_path=self.dataset_path,
                         device=self.device,
                         dataloader_workers=self.dataloader_workers,
-                        valid_size=self.valid_size,
+                        test_size=self.test_size,
                     )
                 elif self.supernet == 'transformer_lt_wmt_en_de':
                     runner_predict = TransformerLTRunner(
@@ -927,7 +927,7 @@ class RandomSearchDistributed(RandomSearch):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -948,7 +948,7 @@ class RandomSearchDistributed(RandomSearch):
             verbose=verbose,
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 

--- a/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
@@ -85,7 +85,7 @@ class ImagenetDataProvider(DataProvider):
                 assert isinstance(valid_size, float) and 0 < valid_size < 1
                 valid_size = int(len(train_dataset) * valid_size)
 
-            valid_dataset = self.train_dataset(valid_transforms)
+            valid_dataset = self.train_dataset(valid_transforms)  # TODO(macsz) This is wrong!
             train_indexes, valid_indexes = self.random_sample_valid_set(len(train_dataset), valid_size)
 
             if num_replicas is not None:

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -52,7 +52,7 @@ class OFARunner:
         batch_size: int = 1,
         dataloader_workers: int = 4,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
     ):
         self.supernet = supernet
         self.acc_predictor = acc_predictor
@@ -61,13 +61,14 @@ class OFARunner:
         self.params_predictor = params_predictor
         self.batch_size = batch_size
         self.device = device
-        self.test_size = None
+        self.test_size = test_size
         ImagenetDataProvider.DEFAULT_PATH = dataset_path
         self.ofa_network = ofa_model_zoo.ofa_net(supernet, pretrained=True)
         self.run_config = ImagenetRunConfig(
             test_batch_size=batch_size,
             n_worker=dataloader_workers,
-            valid_size=valid_size,
+            valid_size=test_size,
+        )
         )
 
     def estimate_accuracy_top1(self, subnet_cfg) -> float:

--- a/dynast/utils/nn.py
+++ b/dynast/utils/nn.py
@@ -69,23 +69,12 @@ def accuracy(output, target, topk=(1,)) -> List[float]:
 def validate_classification(
     model,
     data_loader,
-    epoch=0,
     test_size=None,
-    is_openvino=False,
-    is_onnx=False,
-    use_mkldnn=False,
     device='cpu',
-    batch_size=128,
 ):
-    # NOTE(macsz): if `use_mkldnn` is set to True and model is an OFA submodel,
-    # please refer to HANDI OFA and follow MKLDNN instructions there.
-
     test_criterion = nn.CrossEntropyLoss()
 
-    if (not is_openvino) and (not is_onnx):
-        if not isinstance(model, nn.DataParallel):
-            model = nn.DataParallel(model)
-        model = model.eval()
+    model = model.eval()
 
     losses = AverageMeter()
     top1 = AverageMeter()
@@ -96,12 +85,8 @@ def validate_classification(
     else:
         total = len(data_loader)
 
-    def to_numpy(tensor):
-        return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
-
     with torch.no_grad():
-        for i, (images, labels) in enumerate(data_loader):
-            epoch += 1
+        for epoch, (images, labels) in enumerate(data_loader):
             log.debug(
                 "Validate #{}/{} {}".format(
                     epoch,
@@ -116,47 +101,15 @@ def validate_classification(
             )
             images, labels = images.to(device), labels.to(device)
 
-            if use_mkldnn:
-                images = images.to_mkldnn()
-
-            # compute output
-            if is_onnx:
-                output = model.run(
-                    [model.get_outputs()[0].name],
-                    {model.get_inputs()[0].name: to_numpy(images)},
-                )
-                output = torch.from_numpy(output[0]).to(device)
-            elif is_openvino:
-                expected_batch_size = model.inputs["input"].shape[0]
-                img = to_numpy(images)
-                batch_size = len(img)
-
-                # openvino cannot handle dynamic batch sizes, so for
-                # the last batch of dataset, zero pad the batch size
-                if batch_size != expected_batch_size:
-                    assert batch_size < expected_batch_size, "Assert batch_size:{} < expected_batch_size:{}".format(
-                        batch_size, expected_batch_size
-                    )
-                    npad = expected_batch_size - batch_size
-                    img = np.pad(img, ((0, npad), (0, 0), (0, 0), (0, 0)), mode="constant")
-                    img = img.copy()
-
-                output = model.infer(inputs={"input": img})
-                output = torch.Tensor(output["output"])[:batch_size]
-            else:
-                output = model(images)
-
-            if use_mkldnn:
-                output = output.to_dense()
+            output = model(images)
 
             loss = test_criterion(output, labels)
-            # measure accuracy and record loss
             acc1, acc5 = accuracy(output, labels, topk=(1, 5))
 
             losses.update(loss.item(), images.size(0))
             top1.update(acc1, images.size(0))
             top5.update(acc5, images.size(0))
-            if i > total:
+            if epoch > total:
                 break
     return losses.avg, top1.avg, top5.avg
 

--- a/dynast/utils/nn.py
+++ b/dynast/utils/nn.py
@@ -89,7 +89,7 @@ def validate_classification(
         for epoch, (images, labels) in enumerate(data_loader):
             log.debug(
                 "Validate #{}/{} {}".format(
-                    epoch,
+                    epoch + 1,
                     total,
                     {
                         "loss": losses.avg,
@@ -109,7 +109,7 @@ def validate_classification(
             losses.update(loss.item(), images.size(0))
             top1.update(acc1, images.size(0))
             top5.update(acc5, images.size(0))
-            if epoch > total:
+            if epoch + 1 >= total:
                 break
     return losses.avg, top1.avg, top5.avg
 

--- a/dynast/utils/reference.py
+++ b/dynast/utils/reference.py
@@ -104,8 +104,6 @@ class TorchVisionReference(Reference):
         loss, top1, top5 = validate_classification(
             model=model,
             device=device,
-            is_openvino=False,
-            batch_size=batch_size,
             data_loader=self.dataset.validation_dataloader(
                 batch_size=batch_size,
                 image_size=input_size,

--- a/tests/scripts/config.sh
+++ b/tests/scripts/config.sh
@@ -13,7 +13,7 @@ DATASET_IMAGENET_PATH="/datasets/imagenet-ilsvrc2012/"
 SHORT_RANDOM_POPULATION=2
 
 # Limit the number of validation samples to speed up the test.
-SHORT_RANDOM_VALID_SIZE=20
+SHORT_RANDOM_TEST_SIZE=20
 
 
 #################################################################################################

--- a/tests/scripts/run_ofambv3_random_short.sh
+++ b/tests/scripts/run_ofambv3_random_short.sh
@@ -8,7 +8,7 @@ time python run_search.py \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --valid_size ${SHORT_RANDOM_VALID_SIZE} \
+        --test_size ${SHORT_RANDOM_TEST_SIZE} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}

--- a/tests/scripts/run_ofaresnet50_random_short.sh
+++ b/tests/scripts/run_ofaresnet50_random_short.sh
@@ -8,7 +8,7 @@ time python run_search.py \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --valid_size ${SHORT_RANDOM_VALID_SIZE} \
+        --test_size ${SHORT_RANDOM_TEST_SIZE} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}


### PR DESCRIPTION
- simplify `validate_classification` function
- replace `run_manager.validate` with ``validate_classification`. OFA code had a bug: when test size was specified it was using training dataloader instead of test.
- Rename `valid_size` to `test_size`, as it's more truthful and applies to wider range of datasets.