### PR TITLE
Enable search with model accuracy evaluation on a fractional dataset

### DIFF
--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -20,7 +20,7 @@ def _main(args):
         verbose=args.verbose,
         supernet_ckpt_path=args.supernet_ckpt_path,
         device=args.device,
-        test_size=args.test_size,
+        test_fraction=args.test_fraction,
         dataloader_workers=args.dataloader_workers,
         distributed=args.distributed,
     )
@@ -67,12 +67,7 @@ def main():
     parser.add_argument('-d', '--device', default='cpu', type=str, help='Target device to run measurements on.')
     parser.add_argument('--num_evals', default=250, type=int, help='Total number of evaluations during search.')
     parser.add_argument('--batch_size', default=128, type=int, help='Batch size for latency measurement calculation.')
-    parser.add_argument(
-        '--test_size',
-        default=None,
-        type=int,
-        help='How many data samples to use when evaluating model\'s accuracy. If not set all test data will be used.',
-    )
+    parser.add_argument('--test_fraction', default=1.0, type=float, help='Fraction of the validation data to be used for testing and evaluation.')
     parser.add_argument('--dataloader_workers', default=4, type=int, help='How many workers to use when loading data.')
     parser.add_argument('--population', default=50, type=int, help='Population size for each generation')
     parser.add_argument('--results_path', required=True, type=str, help='Path to store search results, csv format')

--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -71,7 +71,7 @@ def main():
         '--test_size',
         default=None,
         type=int,
-        help='How many batches of data to use when evaluating model\'s accuracy.',
+        help='How many data samples to use when evaluating model\'s accuracy. If not set all test data will be used.',
     )
     parser.add_argument('--dataloader_workers', default=4, type=int, help='How many workers to use when loading data.')
     parser.add_argument('--population', default=50, type=int, help='Population size for each generation')

--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -18,7 +18,6 @@ from dynast.dynast_manager import DyNAS
 
 
 def _main(args):
-
     agent = DyNAS(
         supernet=args.supernet,
         optimization_metrics=args.optimization_metrics,
@@ -81,7 +80,12 @@ def main():
     parser.add_argument('-d', '--device', default='cpu', type=str, help='Target device to run measurements on.')
     parser.add_argument('--num_evals', default=250, type=int, help='Total number of evaluations during search.')
     parser.add_argument('--batch_size', default=128, type=int, help='Batch size for latency measurement calculation.')
-    parser.add_argument('--test_fraction', default=1.0, type=float, help='Fraction of the validation data to be used for testing and evaluation.')
+    parser.add_argument(
+        '--test_fraction',
+        default=1.0,
+        type=float,
+        help='Fraction of the validation data to be used for testing and evaluation.',
+    )
     parser.add_argument('--dataloader_workers', default=4, type=int, help='How many workers to use when loading data.')
     parser.add_argument('--population', default=50, type=int, help='Population size for each generation')
     parser.add_argument('--results_path', required=True, type=str, help='Path to store search results, csv format')

--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -20,7 +20,7 @@ def _main(args):
         verbose=args.verbose,
         supernet_ckpt_path=args.supernet_ckpt_path,
         device=args.device,
-        valid_size=args.valid_size,
+        test_size=args.test_size,
         dataloader_workers=args.dataloader_workers,
         distributed=args.distributed,
     )
@@ -68,7 +68,7 @@ def main():
     parser.add_argument('--num_evals', default=250, type=int, help='Total number of evaluations during search.')
     parser.add_argument('--batch_size', default=128, type=int, help='Batch size for latency measurement calculation.')
     parser.add_argument(
-        '--valid_size',
+        '--test_size',
         default=None,
         type=int,
         help='How many batches of data to use when evaluating model\'s accuracy.',

--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -193,6 +193,7 @@ class NASBaseConfig:
                 test_size=self.test_size,
             )
         elif self.supernet == 'transformer_lt_wmt_en_de':
+            # TODO(macsz) Add `test_size`
             self.runner_validate = TransformerLTRunner(
                 supernet=self.supernet,
                 dataset_path=self.dataset_path,
@@ -200,6 +201,7 @@ class NASBaseConfig:
                 checkpoint_path=self.supernet_ckpt_path,
             )
         elif self.supernet == 'bert_base_sst2':
+            # TODO(macsz) Add `test_size`
             self.runner_validate = BertSST2Runner(
                 supernet=self.supernet,
                 dataset_path=self.dataset_path,

--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -49,7 +49,7 @@ class NASBaseConfig:
         search_algo: str = 'nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -81,7 +81,7 @@ class NASBaseConfig:
         self.supernet_ckpt_path = supernet_ckpt_path
         self.device = device
         self.dataloader_workers = dataloader_workers
-        self.valid_size = valid_size
+        self.test_size = test_size
 
         self.verify_measurement_types()
         self.format_csv_header()
@@ -190,7 +190,7 @@ class NASBaseConfig:
                 batch_size=self.batch_size,
                 device=self.device,
                 dataloader_workers=self.dataloader_workers,
-                valid_size=self.valid_size,
+                test_size=self.test_size,
             )
         elif self.supernet == 'transformer_lt_wmt_en_de':
             self.runner_validate = TransformerLTRunner(
@@ -245,7 +245,7 @@ class LINAS(NASBaseConfig):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -276,7 +276,7 @@ class LINAS(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -346,7 +346,7 @@ class LINAS(NASBaseConfig):
                     dataset_path=self.dataset_path,
                     device=self.device,
                     dataloader_workers=self.dataloader_workers,
-                    valid_size=self.valid_size,
+                    test_size=self.test_size,
                 )
             elif self.supernet == 'transformer_lt_wmt_en_de':
                 runner_predict = TransformerLTRunner(
@@ -494,7 +494,7 @@ class Evolutionary(NASBaseConfig):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path=None,
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         device: str = 'cpu',
         **kwargs,
@@ -513,7 +513,7 @@ class Evolutionary(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -632,7 +632,7 @@ class RandomSearch(NASBaseConfig):
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -650,7 +650,7 @@ class RandomSearch(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -688,7 +688,7 @@ class LINASDistributed(LINAS):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -710,7 +710,7 @@ class LINASDistributed(LINAS):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 
@@ -782,7 +782,7 @@ class LINASDistributed(LINAS):
                         dataset_path=self.dataset_path,
                         device=self.device,
                         dataloader_workers=self.dataloader_workers,
-                        valid_size=self.valid_size,
+                        test_size=self.test_size,
                     )
                 elif self.supernet == 'transformer_lt_wmt_en_de':
                     runner_predict = TransformerLTRunner(
@@ -927,7 +927,7 @@ class RandomSearchDistributed(RandomSearch):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
-        valid_size: int = None,
+        test_size: int = None,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -948,7 +948,7 @@ class RandomSearchDistributed(RandomSearch):
             verbose=verbose,
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
-            valid_size=valid_size,
+            test_size=test_size,
             dataloader_workers=dataloader_workers,
         )
 

--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -49,7 +49,7 @@ class NASBaseConfig:
         search_algo: str = 'nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -81,7 +81,7 @@ class NASBaseConfig:
         self.supernet_ckpt_path = supernet_ckpt_path
         self.device = device
         self.dataloader_workers = dataloader_workers
-        self.test_size = test_size
+        self.test_fraction = test_fraction
 
         self.verify_measurement_types()
         self.format_csv_header()
@@ -190,10 +190,10 @@ class NASBaseConfig:
                 batch_size=self.batch_size,
                 device=self.device,
                 dataloader_workers=self.dataloader_workers,
-                test_size=self.test_size,
+                test_fraction=self.test_fraction,
             )
         elif self.supernet == 'transformer_lt_wmt_en_de':
-            # TODO(macsz) Add `test_size`
+            # TODO(macsz) Add `test_fraction`
             self.runner_validate = TransformerLTRunner(
                 supernet=self.supernet,
                 dataset_path=self.dataset_path,
@@ -201,7 +201,7 @@ class NASBaseConfig:
                 checkpoint_path=self.supernet_ckpt_path,
             )
         elif self.supernet == 'bert_base_sst2':
-            # TODO(macsz) Add `test_size`
+            # TODO(macsz) Add `test_fraction`
             self.runner_validate = BertSST2Runner(
                 supernet=self.supernet,
                 dataset_path=self.dataset_path,
@@ -247,7 +247,7 @@ class LINAS(NASBaseConfig):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -278,7 +278,7 @@ class LINAS(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            test_size=test_size,
+            test_fraction=test_fraction,
             dataloader_workers=dataloader_workers,
         )
 
@@ -348,7 +348,7 @@ class LINAS(NASBaseConfig):
                     dataset_path=self.dataset_path,
                     device=self.device,
                     dataloader_workers=self.dataloader_workers,
-                    test_size=self.test_size,
+                    test_fraction=self.test_fraction,
                 )
             elif self.supernet == 'transformer_lt_wmt_en_de':
                 runner_predict = TransformerLTRunner(
@@ -496,7 +496,7 @@ class Evolutionary(NASBaseConfig):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path=None,
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         device: str = 'cpu',
         **kwargs,
@@ -515,7 +515,7 @@ class Evolutionary(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            test_size=test_size,
+            test_fraction=test_fraction,
             dataloader_workers=dataloader_workers,
         )
 
@@ -634,7 +634,7 @@ class RandomSearch(NASBaseConfig):
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -652,7 +652,7 @@ class RandomSearch(NASBaseConfig):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            test_size=test_size,
+            test_fraction=test_fraction,
             dataloader_workers=dataloader_workers,
         )
 
@@ -690,7 +690,7 @@ class LINASDistributed(LINAS):
         batch_size: int = 1,
         supernet_ckpt_path: str = None,
         device: str = 'cpu',
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -712,7 +712,7 @@ class LINASDistributed(LINAS):
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
             device=device,
-            test_size=test_size,
+            test_fraction=test_fraction,
             dataloader_workers=dataloader_workers,
         )
 
@@ -784,7 +784,7 @@ class LINASDistributed(LINAS):
                         dataset_path=self.dataset_path,
                         device=self.device,
                         dataloader_workers=self.dataloader_workers,
-                        test_size=self.test_size,
+                        test_fraction=self.test_fraction,
                     )
                 elif self.supernet == 'transformer_lt_wmt_en_de':
                     runner_predict = TransformerLTRunner(
@@ -929,7 +929,7 @@ class RandomSearchDistributed(RandomSearch):
         verbose=False,
         search_algo='nsga2',
         supernet_ckpt_path: str = None,
-        test_size: int = None,
+        test_fraction: float = 1.0,
         dataloader_workers: int = 4,
         **kwargs,
     ):
@@ -950,7 +950,7 @@ class RandomSearchDistributed(RandomSearch):
             verbose=verbose,
             search_algo=search_algo,
             supernet_ckpt_path=supernet_ckpt_path,
-            test_size=test_size,
+            test_fraction=test_fraction,
             dataloader_workers=dataloader_workers,
         )
 

--- a/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
@@ -193,7 +193,7 @@ class ImagenetDataProvider(DataProvider):
     def normalize(self):
         return transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 
-    def build_train_transform(self, image_size=None, print_log=True):
+    def build_train_transform(self, image_size=None, print_log=False):
         if image_size is None:
             image_size = self.image_size
         if print_log:

--- a/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/data_providers/imagenet.py
@@ -85,7 +85,7 @@ class ImagenetDataProvider(DataProvider):
                 assert isinstance(valid_size, float) and 0 < valid_size < 1
                 valid_size = int(len(train_dataset) * valid_size)
 
-            valid_dataset = self.train_dataset(valid_transforms)
+            valid_dataset = self.train_dataset(valid_transforms)  # TODO(macsz) This is wrong!
             train_indexes, valid_indexes = self.random_sample_valid_set(len(train_dataset), valid_size)
 
             if num_replicas is not None:

--- a/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/run_manager/run_manager.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/run_manager/run_manager.py
@@ -67,7 +67,7 @@ class RunManager:
             init_models(run_config.model_init)
 
         # net info
-        net_info = get_net_info(self.net, self.run_config.data_provider.data_shape, measure_latency, True)
+        net_info = get_net_info(self.net, self.run_config.data_provider.data_shape, measure_latency)
         with open("%s/net_info.txt" % self.path, "w") as fout:
             fout.write(json.dumps(net_info, indent=4) + "\n")
             # noinspection PyBroadException

--- a/dynast/supernetwork/image_classification/ofa/ofa/utils/pytorch_utils.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/utils/pytorch_utils.py
@@ -155,7 +155,7 @@ def measure_net_latency(net, l_type="gpu8", fast=True, input_shape=(3, 224, 224)
     return total_time / n_sample, measured_latency
 
 
-def get_net_info(net, input_shape=(3, 224, 224), measure_latency=None, print_info=True):
+def get_net_info(net, input_shape=(3, 224, 224), measure_latency=None, print_info=False):
     net_info = {}
     if isinstance(net, nn.DataParallel):
         net = net.module

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -76,11 +76,15 @@ class OFARunner:
 
     def _init_data(self):
         ImageNet.PATH = self.dataset_path
-        self.dataloader = ImageNet.validation_dataloader(
-            batch_size=self.batch_size,
-            num_workers=self.dataloader_workers,
-            fraction=self.test_fraction,
-        )
+        if self.dataset_path:
+            self.dataloader = ImageNet.validation_dataloader(
+                batch_size=self.batch_size,
+                num_workers=self.dataloader_workers,
+                fraction=self.test_fraction,
+            )
+        else:
+            self.dataloader = None
+            log.warning('No dataset path provided. Cannot validate sub-networks.')
 
     def estimate_accuracy_top1(self, subnet_cfg) -> float:
         top1 = self.acc_predictor.predict(subnet_cfg)

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -112,7 +112,6 @@ class OFARunner:
         loss, top1, top5 = validate_classification(
             model=subnet,
             data_loader=self.dataloader,
-            test_size=self.test_size,
             device=self.device,
         )
 

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -32,7 +32,8 @@ from dynast.supernetwork.image_classification.ofa.ofa.imagenet_classification.ru
     RunManager,
 )
 from dynast.utils import log
-from dynast.utils.nn import get_macs, get_parameters, measure_latency
+from dynast.utils.datasets import ImageNet
+from dynast.utils.nn import get_macs, get_parameters, measure_latency, validate_classification
 
 
 class OFARunner:
@@ -52,7 +53,7 @@ class OFARunner:
         batch_size: int = 1,
         dataloader_workers: int = 4,
         device: str = 'cpu',
-        valid_size: int = None,
+        test_size: int = None,
     ):
         self.supernet = supernet
         self.acc_predictor = acc_predictor
@@ -61,13 +62,24 @@ class OFARunner:
         self.params_predictor = params_predictor
         self.batch_size = batch_size
         self.device = device
-        self.test_size = None
+        self.test_size = test_size
+        self.dataset_path = dataset_path
+        self.dataloader_workers = dataloader_workers
         ImagenetDataProvider.DEFAULT_PATH = dataset_path
+
         self.ofa_network = ofa_model_zoo.ofa_net(supernet, pretrained=True)
         self.run_config = ImagenetRunConfig(
             test_batch_size=batch_size,
             n_worker=dataloader_workers,
-            valid_size=valid_size,
+            valid_size=test_size,
+        )
+        self._init_data()
+
+    def _init_data(self):
+        ImageNet.PATH = self.dataset_path
+        self.dataloader = ImageNet.validation_dataloader(
+            batch_size=self.batch_size,
+            num_workers=self.dataloader_workers,
         )
 
     def estimate_accuracy_top1(self, subnet_cfg) -> float:
@@ -96,8 +108,14 @@ class OFARunner:
 
         # Test sampled subnet
         self.run_config.data_provider.assign_active_img_size(subnet_cfg['r'][0])
-        loss, acc = run_manager.validate(net=subnet, no_logs=True)
-        top1 = acc[0]
+
+        loss, top1, top5 = validate_classification(
+            model=subnet,
+            data_loader=self.dataloader,
+            test_size=self.test_size,
+            device=self.device,
+        )
+
         return top1
 
     def validate_macs_params(self, subnet_cfg: dict, device: str = None) -> Tuple[int, int]:

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -79,7 +79,7 @@ class OFARunner:
         self.dataloader = ImageNet.validation_dataloader(
             batch_size=self.batch_size,
             num_workers=self.dataloader_workers,
-            fraction=self.test_fraction
+            fraction=self.test_fraction,
         )
 
     def estimate_accuracy_top1(self, subnet_cfg) -> float:

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -54,6 +54,7 @@ class OFARunner:
         dataloader_workers: int = 4,
         device: str = 'cpu',
         test_fraction: float = 1.0,
+        verbose: bool = False,
     ):
         self.supernet = supernet
         self.acc_predictor = acc_predictor
@@ -65,6 +66,7 @@ class OFARunner:
         self.test_fraction = test_fraction
         self.dataset_path = dataset_path
         self.dataloader_workers = dataloader_workers
+        self.verbose = verbose
         ImagenetDataProvider.DEFAULT_PATH = dataset_path
 
         self.ofa_network = ofa_model_zoo.ofa_net(supernet, pretrained=True)

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -53,7 +53,7 @@ class OFARunner:
         batch_size: int = 1,
         dataloader_workers: int = 4,
         device: str = 'cpu',
-        test_size: int = None,
+        test_fraction: float = 1.0,
     ):
         self.supernet = supernet
         self.acc_predictor = acc_predictor
@@ -62,7 +62,7 @@ class OFARunner:
         self.params_predictor = params_predictor
         self.batch_size = batch_size
         self.device = device
-        self.test_size = test_size
+        self.test_fraction = test_fraction
         self.dataset_path = dataset_path
         self.dataloader_workers = dataloader_workers
         ImagenetDataProvider.DEFAULT_PATH = dataset_path
@@ -71,7 +71,6 @@ class OFARunner:
         self.run_config = ImagenetRunConfig(
             test_batch_size=batch_size,
             n_worker=dataloader_workers,
-            valid_size=test_size,
         )
         self._init_data()
 
@@ -80,6 +79,7 @@ class OFARunner:
         self.dataloader = ImageNet.validation_dataloader(
             batch_size=self.batch_size,
             num_workers=self.dataloader_workers,
+            fraction=self.test_fraction
         )
 
     def estimate_accuracy_top1(self, subnet_cfg) -> float:

--- a/dynast/utils/datasets.py
+++ b/dynast/utils/datasets.py
@@ -133,6 +133,7 @@ class ImageNet(Dataset):
         val_dir: str = None,
         shuffle: bool = False,
         num_workers: int = 16,
+        fraction: float = 1.0
     ) -> torch.utils.data.DataLoader:
         if not val_dir:
             val_dir = os.path.join(ImageNet.PATH, "val")
@@ -141,6 +142,13 @@ class ImageNet(Dataset):
             val_dir,
             ImageNet.val_transforms(image_size),
         )
+
+        # Use random subset of validation data if valid fraction specified
+        if ((fraction > 0.0) and (fraction < 1.0)):
+            random_indices = torch.randperm(len(val_dataset))
+            example_count = round(fraction * len(val_dataset))
+            val_dataset = torch.utils.data.Subset(val_dataset, random_indices[:example_count])
+
         val_sampler = torch.utils.data.SequentialSampler(val_dataset)
         val_loader = torch.utils.data.DataLoader(
             val_dataset,

--- a/dynast/utils/datasets.py
+++ b/dynast/utils/datasets.py
@@ -133,7 +133,7 @@ class ImageNet(Dataset):
         val_dir: str = None,
         shuffle: bool = False,
         num_workers: int = 16,
-        fraction: float = 1.0
+        fraction: float = 1.0,
     ) -> torch.utils.data.DataLoader:
         if not val_dir:
             val_dir = os.path.join(ImageNet.PATH, "val")
@@ -144,7 +144,7 @@ class ImageNet(Dataset):
         )
 
         # Use random subset of validation data if valid fraction specified
-        if ((fraction > 0.0) and (fraction < 1.0)):
+        if (fraction > 0.0) and (fraction < 1.0):
             random_indices = torch.randperm(len(val_dataset))
             example_count = round(fraction * len(val_dataset))
             val_dataset = torch.utils.data.Subset(val_dataset, random_indices[:example_count])
@@ -315,7 +315,6 @@ class CustomDataset(Dataset):
         shuffle: bool = True,
         num_workers: int = 16,
     ) -> torch.utils.data.DataLoader:
-
         image_dataset = datasets.ImageFolder(train_dir, data_transforms)
         return torch.utils.data.DataLoader(
             image_dataset,
@@ -334,7 +333,6 @@ class CustomDataset(Dataset):
         shuffle: bool = False,
         num_workers: int = 16,
     ) -> torch.utils.data.DataLoader:
-
         image_dataset = datasets.ImageFolder(val_dir, data_transforms)
         return torch.utils.data.DataLoader(
             image_dataset,

--- a/dynast/utils/nn.py
+++ b/dynast/utils/nn.py
@@ -69,7 +69,6 @@ def accuracy(output, target, topk=(1,)) -> List[float]:
 def validate_classification(
     model,
     data_loader,
-    test_size=None,
     device='cpu',
 ):
     test_criterion = nn.CrossEntropyLoss()
@@ -80,16 +79,13 @@ def validate_classification(
     top1 = AverageMeter()
     top5 = AverageMeter()
 
-    if test_size is not None:
-        total = test_size
-    else:
-        total = len(data_loader)
+    total = len(data_loader)
 
     with torch.no_grad():
-        for epoch, (images, labels) in enumerate(data_loader):
+        for batch, (images, labels) in enumerate(data_loader):
             log.debug(
                 "Validate #{}/{} {}".format(
-                    epoch + 1,
+                    batch + 1,
                     total,
                     {
                         "loss": losses.avg,
@@ -109,8 +105,7 @@ def validate_classification(
             losses.update(loss.item(), images.size(0))
             top1.update(acc1, images.size(0))
             top5.update(acc5, images.size(0))
-            if epoch + 1 >= total:
-                break
+
     return losses.avg, top1.avg, top5.avg
 
 

--- a/dynast/utils/reference.py
+++ b/dynast/utils/reference.py
@@ -104,8 +104,6 @@ class TorchVisionReference(Reference):
         loss, top1, top5 = validate_classification(
             model=model,
             device=device,
-            is_openvino=False,
-            batch_size=batch_size,
             data_loader=self.dataset.validation_dataloader(
                 batch_size=batch_size,
                 image_size=input_size,

--- a/dynast/utils/reference.py
+++ b/dynast/utils/reference.py
@@ -98,7 +98,7 @@ class TorchVisionReference(Reference):
         device: str = 'cpu',
         batch_size: int = 128,
         input_size: int = 224,
-        test_size: int = None,
+        test_fraction: float = 1.0,
     ) -> Tuple[float, float, float]:
         model = self.model.to(device)
         loss, top1, top5 = validate_classification(
@@ -107,8 +107,8 @@ class TorchVisionReference(Reference):
             data_loader=self.dataset.validation_dataloader(
                 batch_size=batch_size,
                 image_size=input_size,
+                fraction=test_fraction
             ),
-            test_size=test_size,  # TODO(macsz) Once the `test_size` functionality is implemented we will have to modify this call accordingly.
         )
         log.info(
             '\'{model_name}\' on \'{dataset_name}\' - top1 {top1} top5 {top5} loss {loss}'.format(

--- a/dynast/utils/reference.py
+++ b/dynast/utils/reference.py
@@ -108,7 +108,7 @@ class TorchVisionReference(Reference):
                 batch_size=batch_size,
                 image_size=input_size,
             ),
-            test_size=test_size,
+            test_size=test_size,  # TODO(macsz) Once the `test_size` functionality is implemented we will have to modify this call accordingly.
         )
         log.info(
             '\'{model_name}\' on \'{dataset_name}\' - top1 {top1} top5 {top5} loss {loss}'.format(

--- a/dynast/utils/reference.py
+++ b/dynast/utils/reference.py
@@ -107,7 +107,7 @@ class TorchVisionReference(Reference):
             data_loader=self.dataset.validation_dataloader(
                 batch_size=batch_size,
                 image_size=input_size,
-                fraction=test_fraction
+                fraction=test_fraction,
             ),
         )
         log.info(

--- a/tests/scripts/config.sh
+++ b/tests/scripts/config.sh
@@ -14,7 +14,7 @@ DATASET_IMAGENET_PATH="/datasets/imagenet-ilsvrc2012/"
 SHORT_RANDOM_POPULATION=2
 
 # Limit the number of validation samples to speed up the test.
-SHORT_RANDOM_VALID_SIZE=20
+SHORT_RANDOM_TEST_SIZE=20
 
 
 #################################################################################################

--- a/tests/scripts/config.sh
+++ b/tests/scripts/config.sh
@@ -14,7 +14,7 @@ DATASET_IMAGENET_PATH="/datasets/imagenet-ilsvrc2012/"
 SHORT_RANDOM_POPULATION=2
 
 # Limit the number of validation samples to speed up the test.
-SHORT_RANDOM_TEST_SIZE=20
+SHORT_RANDOM_IMAGENET_TEST_FRACTION=0.005
 
 
 #################################################################################################

--- a/tests/scripts/run_ofambv3_random_short.sh
+++ b/tests/scripts/run_ofambv3_random_short.sh
@@ -8,7 +8,7 @@ time ${RUN_COMMAND} \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --valid_size ${SHORT_RANDOM_VALID_SIZE} \
+        --test_size ${SHORT_RANDOM_TEST_SIZE} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}

--- a/tests/scripts/run_ofambv3_random_short.sh
+++ b/tests/scripts/run_ofambv3_random_short.sh
@@ -8,7 +8,7 @@ time ${RUN_COMMAND} \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --test_size ${SHORT_RANDOM_TEST_SIZE} \
+        --test_fraction ${SHORT_RANDOM_IMAGENET_TEST_FRACTION} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}

--- a/tests/scripts/run_ofaresnet50_random_short.sh
+++ b/tests/scripts/run_ofaresnet50_random_short.sh
@@ -8,7 +8,7 @@ time ${RUN_COMMAND} \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --valid_size ${SHORT_RANDOM_VALID_SIZE} \
+        --test_size ${SHORT_RANDOM_TEST_SIZE} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}

--- a/tests/scripts/run_ofaresnet50_random_short.sh
+++ b/tests/scripts/run_ofaresnet50_random_short.sh
@@ -8,7 +8,7 @@ time ${RUN_COMMAND} \
         --dataset_path  ${DATASET_IMAGENET_PATH} \
         --search_tactic random \
         --population ${SHORT_RANDOM_POPULATION} \
-        --test_size ${SHORT_RANDOM_TEST_SIZE} \
+        --test_fraction ${SHORT_RANDOM_IMAGENET_TEST_FRACTION} \
         --seed ${SEED} \
         --measurements macs accuracy_top1 \
         --num_evals ${SHORT_RANDOM_POPULATION}

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -37,3 +37,12 @@ def test_dataset_invalid_name_exception():
 
     with pytest.raises(Exception):
         Dataset.get(invalid_dataset_name)
+
+
+def test_dataset_test_fraction():
+    dataset = ImageNet()
+    bs = 128
+    imagenet_val_steps = 50000//bs
+    assert len(dataset.validation_dataloader(bs, fraction=1.0)) == imagenet_val_steps
+    assert len(dataset.validation_dataloader(bs, fraction=0.0)) == imagenet_val_steps
+    assert len(dataset.validation_dataloader(bs, fraction=0.2)) == imagenet_val_steps//5


### PR DESCRIPTION
This change adds `test_fraction` argument to both CLI and Python interfaces. `test_fraction` accepts a floating point number in the range of `(0.0, 1.0>` which will scale the number of steps used for model evaluation on ImageNet dataset by the same factor.

Note: This has been implemented only for the ImageNet dataset.