### PR TITLE
Add verbosity option to OFA

### DIFF
--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -191,6 +191,7 @@ class NASBaseConfig:
                 device=self.device,
                 dataloader_workers=self.dataloader_workers,
                 test_size=self.test_size,
+                verbose=self.verbose,
             )
         elif self.supernet == 'transformer_lt_wmt_en_de':
             self.runner_validate = TransformerLTRunner(
@@ -347,6 +348,7 @@ class LINAS(NASBaseConfig):
                     device=self.device,
                     dataloader_workers=self.dataloader_workers,
                     test_size=self.test_size,
+                    verbose=self.verbose,
                 )
             elif self.supernet == 'transformer_lt_wmt_en_de':
                 runner_predict = TransformerLTRunner(
@@ -783,6 +785,7 @@ class LINASDistributed(LINAS):
                         device=self.device,
                         dataloader_workers=self.dataloader_workers,
                         test_size=self.test_size,
+                        verbose=self.verbose,
                     )
                 elif self.supernet == 'transformer_lt_wmt_en_de':
                     runner_predict = TransformerLTRunner(

--- a/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/run_manager/run_manager.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/imagenet_classification/run_manager/run_manager.py
@@ -45,10 +45,20 @@ __all__ = ["RunManager"]
 
 
 class RunManager:
-    def __init__(self, path, net, run_config, init=True, measure_latency=None, no_gpu=False):
+    def __init__(
+        self,
+        path,
+        net,
+        run_config,
+        init=True,
+        measure_latency=None,
+        no_gpu=False,
+        verbose=False,
+    ):
         self.path = path
         self.net = net
         self.run_config = run_config
+        self.verbose = verbose
 
         self.best_acc = 0
         self.start_epoch = 0
@@ -67,7 +77,12 @@ class RunManager:
             init_models(run_config.model_init)
 
         # net info
-        net_info = get_net_info(self.net, self.run_config.data_provider.data_shape, measure_latency, True)
+        net_info = get_net_info(
+            net=self.net,
+            input_shape=self.run_config.data_provider.data_shape,
+            measure_latency=measure_latency,
+            print_info=self.verbose,
+        )
         with open("%s/net_info.txt" % self.path, "w") as fout:
             fout.write(json.dumps(net_info, indent=4) + "\n")
             # noinspection PyBroadException

--- a/dynast/supernetwork/image_classification/ofa/ofa/utils/pytorch_utils.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa/utils/pytorch_utils.py
@@ -155,7 +155,7 @@ def measure_net_latency(net, l_type="gpu8", fast=True, input_shape=(3, 224, 224)
     return total_time / n_sample, measured_latency
 
 
-def get_net_info(net, input_shape=(3, 224, 224), measure_latency=None, print_info=True):
+def get_net_info(net, input_shape=(3, 224, 224), measure_latency=None, print_info=False):
     net_info = {}
     if isinstance(net, nn.DataParallel):
         net = net.module

--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -54,6 +54,7 @@ class OFARunner:
         dataloader_workers: int = 4,
         device: str = 'cpu',
         test_size: int = None,
+        verbose: bool = False,
     ):
         self.supernet = supernet
         self.acc_predictor = acc_predictor
@@ -63,6 +64,7 @@ class OFARunner:
         self.batch_size = batch_size
         self.device = device
         self.test_size = test_size
+        self.verbose = verbose
         self.dataset_path = dataset_path
         self.dataloader_workers = dataloader_workers
         ImagenetDataProvider.DEFAULT_PATH = dataset_path
@@ -103,7 +105,13 @@ class OFARunner:
 
         subnet = self.get_subnet(subnet_cfg)
         folder_name = '/tmp/ofa-tmp-{}'.format(uuid.uuid1().hex)  # TODO(macsz) root directory should be configurable
-        run_manager = RunManager('{}/eval_subnet'.format(folder_name), subnet, self.run_config, init=False)
+        run_manager = RunManager(
+            '{}/eval_subnet'.format(folder_name),
+            subnet,
+            self.run_config,
+            init=False,
+            verbose=self.verbose,
+        )
         run_manager.reset_running_statistics(net=subnet)
 
         # Test sampled subnet


### PR DESCRIPTION
By default OFA prints whole model architecture. This change adds an option to tune verbosity in OFA and by default sets it to disabled.