### PR TITLE
Fix order of columns for TransformerLT and BERT-SST2 in CSV file

### DIFF
--- a/dynast/supernetwork/machine_translation/transformer_interface.py
+++ b/dynast/supernetwork/machine_translation/transformer_interface.py
@@ -629,9 +629,9 @@ class EvaluationInterfaceTransformerLT(EvaluationInterface):
                 result = [
                     subnet_sample,
                     date,
+                    individual_results['params'],
                     individual_results['latency'],
                     individual_results['macs'],
-                    individual_results['params'],
                     individual_results['bleu'],
                 ]
                 writer.writerow(result)

--- a/dynast/supernetwork/text_classification/bert_interface.py
+++ b/dynast/supernetwork/text_classification/bert_interface.py
@@ -344,9 +344,9 @@ class EvaluationInterfaceBertSST2(EvaluationInterface):
                 result = [
                     subnet_sample,
                     date,
+                    individual_results['params'],
                     individual_results['latency'],
                     individual_results['macs'],
-                    individual_results['params'],
                     individual_results['accuracy_sst2'],
                 ]
                 writer.writerow(result)


### PR DESCRIPTION
Order of the columns should be the same as specified in `dynast/search/search_tactic.py:format_csv_header()`.

This will be restructured in a follow-up PR to avoid future mistakes.