### PR TITLE
Add ignore dirs to mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ include = '\.pyi?$'
 
 [tool.mypy]
 python_version = '3.7'
+exclude = ['venv', '.venv', 'build', 'dist']
 files = [
     'dynast',
     'tests',

--- a/tests/checks/helpers.py
+++ b/tests/checks/helpers.py
@@ -23,6 +23,7 @@ IGNORE_DIRS = [
     'log_dir',
     '.idea',
     '.venv',
+    'build',
 ]
 
 


### PR DESCRIPTION
mypy will fail if DyNAS-T build directory is present. With this patch mypy will ignore any build-related directories.

license check should not report findings in `build` dir.