### PR TITLE
Add fraction param to remaining image classification datasets

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -42,7 +42,7 @@ def test_dataset_invalid_name_exception():
 def test_dataset_test_fraction():
     dataset = ImageNet()
     bs = 128
-    imagenet_val_steps = 50000//bs
+    imagenet_val_steps = 50000 // bs
     assert len(dataset.validation_dataloader(bs, fraction=1.0)) == imagenet_val_steps
     assert len(dataset.validation_dataloader(bs, fraction=0.0)) == imagenet_val_steps
-    assert len(dataset.validation_dataloader(bs, fraction=0.2)) == imagenet_val_steps//5
+    assert len(dataset.validation_dataloader(bs, fraction=0.2)) == imagenet_val_steps // 5


### PR DESCRIPTION
So far only validation with the ImageNet could have been performed. This path extends remaining image classification dataset interfaces with `fraction` parameter:
* Imagenette
* CIFAR10
