### PR TITLE
Bug: fix order of transformer-based supernet metrics

### DIFF
--- a/dynast/supernetwork/supernetwork_registry.py
+++ b/dynast/supernetwork/supernetwork_registry.py
@@ -106,8 +106,8 @@ SUPERNET_METRICS = {
     'ofa_mbv3_d234_e346_k357_w1.0': ['params', 'latency', 'macs', 'accuracy_top1'],
     'ofa_mbv3_d234_e346_k357_w1.2': ['params', 'latency', 'macs', 'accuracy_top1'],
     'ofa_proxyless_d234_e346_k357_w1.3': ['params', 'latency', 'macs', 'accuracy_top1'],
-    'transformer_lt_wmt_en_de': ['latency', 'macs', 'params', 'bleu'],
-    'bert_base_sst2': ['latency', 'macs', 'params', 'accuracy_sst2'],
+    'transformer_lt_wmt_en_de': ['params', 'latency', 'macs', 'bleu'],
+    'bert_base_sst2': ['params', 'latency', 'macs', 'accuracy_sst2'],
 }
 
 


### PR DESCRIPTION
Following up on the PR#34, the issue remained that the ordering of data in the CSV result file was not consistent across the DyNAS-T search.

In this particular case, while the data was saved correctly to the CSV file, it was not read properly by the predictor which caused various issues in the search results.