### PR TITLE
Fix OFA interface for ResNet50

### DIFF
--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -191,7 +191,7 @@ class OFARunner:
 
     def get_subnet(self, subnet_cfg):
         if self.supernet == 'ofa_resnet50':
-            self.ofa_network.set_active_subnet(ks=subnet_cfg['d'], e=subnet_cfg['e'], d=subnet_cfg['w'])
+            self.ofa_network.set_active_subnet(d=subnet_cfg['d'], e=subnet_cfg['e'], w=subnet_cfg['w'])
         else:
             self.ofa_network.set_active_subnet(ks=subnet_cfg['ks'], e=subnet_cfg['e'], d=subnet_cfg['d'])
 


### PR DESCRIPTION
The `get_subnet` method in `OFARunner` was using improper keys for the resnet50 supernetwork.

To start with, it used `ks` which is only applicable to MobileNetV3 supernets and passed depth as it's value. Unused (`ks`) param will be ignored, but the depth, as it was not set, will take the default value of None, resulting in a limited search space.

Secondly, the depth param was set to width value. Valid values for both depth and width are the same, so there was no raised error.

![results_ofaresnet50_linas_long_main_comp](https://github.com/IntelLabs/DyNAS-T/assets/4785345/9a05b8e9-fda6-4098-87c3-b4c51d0431ee)
