### PR TITLE
Fix: load model to a target device

### DIFF
--- a/dynast/utils/nn.py
+++ b/dynast/utils/nn.py
@@ -73,6 +73,7 @@ def validate_classification(
 ):
     test_criterion = nn.CrossEntropyLoss()
 
+    model.to(device)
     model = model.eval()
 
     losses = AverageMeter()


### PR DESCRIPTION
Image classification model was not moving model to a target device, which may result in tensor errors. This PR fixed this issue.