### PR TITLE
Update DyNAS interface

### DIFF
--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -28,11 +28,10 @@ class DyNAS:
     '''
 
     def __new__(
-            self,
-            search_tactic: str = 'linas',
-            **kwargs,
-        ):
-
+        self,
+        search_tactic: str = 'linas',
+        **kwargs,
+    ):
         kwargs.update(search_tactic=search_tactic)
 
         log_level = logging.INFO

--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -39,15 +39,17 @@ class DyNAS:
         dataset_path: str = None,
         **kwargs,
     ):
-        kwargs.update({
-            'supernet': supernet,
-            'results_path': results_path,
-            'optimization_metrics': optimization_metrics,
-            'measurements': measurements,
-            'search_tactic': search_tactic,
-            'num_evals': num_evals,
-            'dataset_path': dataset_path,
-        })
+        kwargs.update(
+            {
+                'supernet': supernet,
+                'results_path': results_path,
+                'optimization_metrics': optimization_metrics,
+                'measurements': measurements,
+                'search_tactic': search_tactic,
+                'num_evals': num_evals,
+                'dataset_path': dataset_path,
+            }
+        )
 
         log_level = logging.INFO
         if kwargs.get('verbose'):

--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -14,6 +14,7 @@
 
 import logging
 import sys
+from typing import List
 
 from dynast.search.search_tactic import LINAS, Evolutionary, LINASDistributed, RandomSearch, RandomSearchDistributed
 from dynast.utils import check_kwargs_deprecated, log, set_logger
@@ -29,10 +30,24 @@ class DyNAS:
 
     def __new__(
         self,
+        supernet: str,
+        results_path: str,
+        optimization_metrics: List[str],
+        measurements: List[str],
         search_tactic: str = 'linas',
+        num_evals: int = 250,
+        dataset_path: str = None,
         **kwargs,
     ):
-        kwargs.update(search_tactic=search_tactic)
+        kwargs.update({
+            'supernet': supernet,
+            'results_path': results_path,
+            'optimization_metrics': optimization_metrics,
+            'measurements': measurements,
+            'search_tactic': search_tactic,
+            'num_evals': num_evals,
+            'dataset_path': dataset_path,
+        })
 
         log_level = logging.INFO
         if kwargs.get('verbose'):
@@ -50,22 +65,6 @@ class DyNAS:
         log.info('=' * 40)
         log.info('Starting Dynamic NAS Toolkit (DyNAS-T)')
         log.info('=' * 40)
-
-        # Required arguments for the DyNAS class
-        # TODO(macsz) If these are common for all created classes, then we can move it out of kwargs
-        REQUIRED_KWARGS = [
-            'supernet',
-            'optimization_metrics',
-            'measurements',
-            'num_evals',
-            'results_path',
-        ]
-
-        # Validity checks
-        for argument in REQUIRED_KWARGS:
-            if argument not in kwargs:
-                log.error(f"Missing `--{argument}` parameter.")
-                sys.exit("Missing argument, see log file for info.")
 
         kwargs = check_kwargs_deprecated(**kwargs)
 

--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -27,7 +27,14 @@ class DyNAS:
     with this class based on the user input.
     '''
 
-    def __new__(self, **kwargs):
+    def __new__(
+            self,
+            search_tactic: str = 'linas',
+            **kwargs,
+        ):
+
+        kwargs.update(search_tactic=search_tactic)
+
         log_level = logging.INFO
         if kwargs.get('verbose'):
             log_level = logging.DEBUG
@@ -51,10 +58,8 @@ class DyNAS:
             'supernet',
             'optimization_metrics',
             'measurements',
-            'search_tactic',
             'num_evals',
             'results_path',
-            'dataset_path',
         ]
 
         # Validity checks
@@ -77,34 +82,34 @@ class DyNAS:
 
         if kwargs.get('distributed', False):
             # LINAS bi-level evolutionary algorithm search distributed to multiple workers
-            if kwargs['search_tactic'] == 'linas':
+            if search_tactic == 'linas':
                 log.info('Initializing DyNAS LINAS (distributed) algorithm object.')
                 return LINASDistributed(**kwargs)
 
                 # Uniform random sampling of the architectural space distributed to multiple workers
-            elif kwargs['search_tactic'] == 'random':
+            elif search_tactic == 'random':
                 log.info('Initializing DyNAS random (distributed) search algorithm object.')
                 return RandomSearchDistributed(**kwargs)
 
         # LINAS bi-level evolutionary algorithm search
-        if kwargs['search_tactic'] == 'linas':
+        if search_tactic == 'linas':
             log.info('Initializing DyNAS LINAS algorithm object.')
             return LINAS(**kwargs)
 
         # Standard evolutionary algorithm search
-        elif kwargs['search_tactic'] == 'evolutionary':
+        elif search_tactic == 'evolutionary':
             log.info('Initializing DyNAS evoluationary algorithm object.')
             return Evolutionary(**kwargs)
 
         # Uniform random sampling of the architectural space
-        elif kwargs['search_tactic'] == 'random':
+        elif search_tactic == 'random':
             log.info('Initializing DyNAS random search algorithm object.')
             return RandomSearch(**kwargs)
 
         else:
             error_message = (
                 "Invalid `--search_tactic` parameter `{}` (options: 'linas', 'evolutionary', 'random').".format(
-                    kwargs['search_tactic']
+                    search_tactic
                 )
             )  # TODO(macsz) Un-hardcode options.
             log.error(error_message)

--- a/tests/test_dynast_manager.py
+++ b/tests/test_dynast_manager.py
@@ -18,12 +18,6 @@ from dynast.dynast_manager import DyNAS
 from dynast.search.search_tactic import LINAS, Evolutionary, LINASDistributed, RandomSearch, RandomSearchDistributed
 
 
-def test_dynas_not_enough_args_passed_exits():
-    # Not all params passed
-    with pytest.raises(SystemExit):
-        DyNAS(supernet='ofa_resnet50')
-
-
 def test_dynas_optimization_metrics_unsupported_number():
     with pytest.raises(SystemExit):
         DyNAS(


### PR DESCRIPTION
* `search_tactic` has a default value of `linas`; no longer required to explicitly specify.
* `num_evals` has a default value of `250`; no longer required to explicitly specify.
* `dataset_path` has a default value of None; no longer required to explicitly specify. Runs that either do not evaluate for accuracy or use custom data loaders do not need dataset to be specified.