### PR TITLE
Add test for presence of `__init__.py` files in packages

### DIFF
--- a/tests/checks/check_package.py
+++ b/tests/checks/check_package.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from tests.checks.helpers import get_packages_paths
+
+ROOT_DIR = os.getcwd()
+
+
+@pytest.mark.parametrize('dir_path', get_packages_paths(ROOT_DIR))
+def test_check_init_files(dir_path):
+    fn = os.path.join(dir_path, '__init__.py')
+    assert os.path.exists(fn), f"Package {dir_path} does not contain `__init__.py` file!"

--- a/tests/checks/helpers.py
+++ b/tests/checks/helpers.py
@@ -24,6 +24,19 @@ IGNORE_DIRS = [
     '.idea',
     '.venv',
     'build',
+    'nc_workspace',
+    'docs',
+    '__pycache__',
+    '.pytest_cache',
+    'dynast.egg-info',
+    '.torch',
+    '.github',
+    'notebooks',
+    'models',
+    'out',
+    'results',
+    'tmp',
+    'scripts',
 ]
 
 
@@ -40,3 +53,30 @@ def get_python_files(root_dir, exclude_files=None):
             files.extend(glob(os.path.join(d, pattern)))
 
     return list(sorted(set(files) - set(exclude_files)))
+
+
+def get_packages_paths(root_dir, exclude_files=None):
+    if not exclude_files:
+        exclude_files = []
+
+    subdirs = []
+    dirs = list(os.walk(root_dir))[1:]  # [1:] to exclude DyNAS-T's root dir
+    for x in dirs:
+        subdir = x[0]
+        is_ok = True
+        for ignored_dir in IGNORE_DIRS:
+            if ignored_dir in subdir or f'./{ignored_dir}' in subdir:
+                is_ok = False
+        for ignored_dir in exclude_files:
+            if ignored_dir in subdir or f'./{ignored_dir}' in subdir:
+                is_ok = False
+
+        # Check if subdir actually has any python files inside (or if there are subdirs)
+        pys = [tmp_path for tmp_path in os.listdir(subdir) if tmp_path.endswith('.py') or os.path.isdir(tmp_path)]
+        if not pys:
+            continue
+
+        if is_ok:
+            subdirs.append(subdir)
+
+    return subdirs

--- a/tests/search/__init__.py
+++ b/tests/search/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/supernetwork/__init__.py
+++ b/tests/supernetwork/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/supernetwork/image_classification/__init__.py
+++ b/tests/supernetwork/image_classification/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/supernetwork/image_classification/bootstrapnas/__init__.py
+++ b/tests/supernetwork/image_classification/bootstrapnas/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This software is subject to the terms and conditions entered into between the parties.

--- a/tests/supernetwork/image_classification/ofa/__init__.py
+++ b/tests/supernetwork/image_classification/ofa/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This software is subject to the terms and conditions entered into between the parties.

--- a/tests/supernetwork/test_classification/__init__.py
+++ b/tests/supernetwork/test_classification/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This software is subject to the terms and conditions entered into between the parties.

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This software is subject to the terms and conditions entered into between the parties.


### PR DESCRIPTION
Missing `__init__.py` files are resulting in missing packages from the build PyPI wheel. To avoid this in the future this PR adds check for init files on the CI.