### PR TITLE
Add markdown lint check to CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,21 @@ name: Unit Tests
 
 on: [push]
 jobs:
+  markdown-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+      - name: markdown-check
+        run: |
+          python -m pymarkdown -d MD013 scan .
   code-check:
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +63,7 @@ jobs:
         run: |
           python -m black --check --diff --color -S .
   pytest:
-    needs: [isort, lint, code-check]
+    needs: [isort, lint, code-check, markdown-check]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
           pip install -r requirements_test.txt
       - name: markdown-check
         run: |
-          python -m pymarkdown -d MD013 scan .
+          python -m pymarkdown -d MD013,MD033,MD034 scan .
   code-check:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,13 +28,7 @@ Please note: the `linter.sh` script is also integrated into our Continuous Integ
 
 By adhering to these guidelines, you help us maintain a clean and consistent codebase. We appreciate your understanding and effort in this regard.
 
-> TL;DR: You can run automated linting and checks with:
->
-> ```bash
-> ./linter.sh
-> ```
-> It's advised to run this script before every `git commit`.
-
+> TL;DR: You can run automated linting and checks with: `./linter.sh`. It's advised to run this script before every `git commit`.
 
 ## Testing
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -17,6 +17,7 @@ limitations under the License.
 ## 3rd party Licenses
 
 ### OFA
+
 MIT License
 
 Copyright (c) 2021 Han Cai

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ The following number of optimization algorithms are supported by DyNAS-T in both
 
 | 1 Objective<br/>(Single-Objective) | 2 Objectives<br/>(Multi-Objective) | 3 Objectives<br/>(Many-Objective) |
 |------------------|-----------------|----------------|
-| GA* `'ga'`   | NSGA-II* `'nsga2'` | UNSGA-II* `'unsga3'`     |
+| GA* `'ga'`   | NSGA-II\* `'nsga2'` | UNSGA-II\* `'unsga3'`     |
 | CMA-ES `'cmaes'` | AGE-MOEA `'age'` | CTAEA `'ctaea'`         |
 |        |          | MOEAD `'moead'`          |
-*Recommended for stability of search results
+\*Recommended for stability of search results
 
 ## Super-networks
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![DyNAS-T Logo](https://github.com/IntelLabs/DyNAS-T/blob/main/docs/images/dynast_logo.png?raw=true)
-
 # DyNAS-T
+
+![DyNAS-T Logo](https://github.com/IntelLabs/DyNAS-T/blob/main/docs/images/dynast_logo.png?raw=true)
 
 [![PyPI DyNAS-T](https://img.shields.io/pypi/v/dynast)](https://pypi.org/project/dynast/) [![Python Versions](https://img.shields.io/pypi/pyversions/dynast)](https://pypi.org/project/dynast/) [![image](https://img.shields.io/badge/license-Apache--2-blue.svg?style=flat)](http://www.apache.org/licenses/LICENSE-2.0) [![Monthly Downloads](https://img.shields.io/pypi/dm/dynast)](https://pypi.org/project/dynast/)
 
@@ -25,7 +25,7 @@ A unique capability of DyNAS-T is the Lightweight Iterative NAS (LINAS) that pai
 
 The following number of optimization algorithms are supported by DyNAS-T in both standard and LINAS formats.
 
-| 1 Objective<br>(Single-Objective) | 2 Objectives<br>(Multi-Objective) | 3 Objectives<br>(Many-Objective) |
+| 1 Objective<br/>(Single-Objective) | 2 Objectives<br/>(Multi-Objective) | 3 Objectives<br/>(Many-Objective) |
 |------------------|-----------------|----------------|
 | GA* `'ga'`   | NSGA-II* `'nsga2'` | UNSGA-II* `'unsga3'`     |
 | CMA-ES `'cmaes'` | AGE-MOEA `'age'` | CTAEA `'ctaea'`         |
@@ -33,6 +33,7 @@ The following number of optimization algorithms are supported by DyNAS-T in both
 *Recommended for stability of search results
 
 ## Super-networks
+
 DyNAS-T included support for the following super-network frameworks suchs as [Once-for-All (OFA)](https://github.com/mit-han-lab/once-for-all).
 
 | Super-Network | Model Name | Dataset | Objectives/Measurements Supported |
@@ -46,19 +47,18 @@ DyNAS-T included support for the following super-network frameworks suchs as [On
 |BERT-SST2 | bert_base_sst2 | [SST2](https://huggingface.co/datasets/sst2) | `latency`, `macs`, `params`, `accuracy_sst2` |
 |BootstrapNAS | - | - | `accuracy_top1`, `macs`, `params`, `latency` |
 
-
 > **_ImageNet:_**  When using any of the OFA super-networks, the ImageNet directory tree should have a separate directory for each of the classes in both `train` and `val` sets. To prepare your ImageNet dataset for use with OFA you could follow instructions available [here](https://jkjung-avt.github.io/ilsvrc2012-in-digits/).
-
 > **_WMT En-De:_** To obtain and prepare dataset please follow instructions available [here](https://github.com/mit-han-lab/hardware-aware-transformers).
-
 > **_BootstrapNAS_**: BootstrapNAS is currently only avaiable through the Python interface. To read more how to use DyNAS-T on BootstrapNAS search space, please refer to [the example notebook](https://github.com/macsz/Hardware-Aware-Automated-Machine-Learning/blob/macsz/dynast/examples/bootstrapNAS/third_party_search/dynas-t_external_search_resnet50_supernet.ipynb).
 
 ## Intel Library Support
+
 The following software libraries are compatible with DyNAS-T:
+
 * [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor/blob/master/examples/notebook/dynas/MobileNetV3_Supernet_NAS.ipynb)
 * [Intel OpenVINO NNCF BootstrapNAS](https://github.com/openvinotoolkit/nncf/blob/develop/nncf/experimental/torch/nas/bootstrapNAS/BootstrapNAS.md)
 
-# Getting Started
+## Getting Started
 
 To setup DyNAS-T from source code run `pip install -e .` or make a local copy of the `dynast` subfolder in your
 local subnetwork repository with the `requirements.txt` dependencies installed.
@@ -71,8 +71,8 @@ pip install dynast
 
 Installing DyNAS-T with `pip` will make a `dynast` command available in your CLI.
 
+### Running DyNAS-T
 
-## Running DyNAS-T
 The `dynast/cli.py` (you can use `dynast` command to invoke this script) template provide a starting point for running the NAS process. An evaluation is the process of determining the fitness of an architectural candidate. A *validation* evaluation is the costly process of running the full validation set. A *predictor* evaluation uses a pre-trained performance predictor.
 
 * `supernet` - Name of the pre-trained super-network. See list of supported super-networks. For a custom super-network, you will have to modify the code including the `dynast_manager.py` and `supernetwork_registry.py` files.
@@ -86,7 +86,7 @@ The `dynast/cli.py` (you can use `dynast` command to invoke this script) templat
 * `results_path` - The location of the csv file that store information of the DNN candidates during the search process. The csv file is used for plotting NAS results.
 * `dataset_path` - Location of the dataset used for training the super-network of interest.
 
-### Single-Objective
+#### Single-Objective
 
 *Example 1a.* NAS process for the OFA MobileNetV3-w1.0 super-network that optimizes for ImageNet Top-1 accuracy using a simple evolutionary genetic algorithm (GA) approach.
 
@@ -114,7 +114,7 @@ dynast \
     --search_algo ga
 ```
 
-### Multi-Objective
+#### Multi-Objective
 
 *Example 2a.* NAS process for the OFA MobileNetV3-w1.0 super-network that optimizes for ImageNet Top-1 accuracy *and* multiply-and-accumulates (MACs) using a LINAS+NSGA-II approach.
 
@@ -142,7 +142,7 @@ dynast \
     --search_algo age
 ```
 
-### Many-Objective
+#### Many-Objective
 
 *Example 3a.* NAS process for the OFA ResNet50 super-network that optimizes for ImageNet Top-1 accuracy *and* model size (parameters) *and* multiply-and-accumulates (MACs) using a evolutionary unsga3 approach.
 
@@ -173,8 +173,7 @@ dynast \
 An example of the search results for a Multi-Objective search using both LINAS+NSGA-II and standard NSGA-II algorithms will yield results in the following format.
 ![DyNAS-T Results](https://github.com/IntelLabs/DyNAS-T/blob/main/docs/images/search_results.png?raw=true)
 
-
-### Quantization-aware Search
+#### Quantization-aware Search
 
 This approach allows you to run search on your FP32 super-network and find optimal model configurations w.r.t. both architecture and Post-Training Quantization policy. DyNAS-T's implementation uses [Intel® Neural Compressor](https://github.com/intel/neural-compressor) as an underlying backend for quantizing models. This search approach is specific to the CPU, and so `--device=cpu` has to be used.
 
@@ -193,7 +192,7 @@ dynast \
         --seed 42
 ```
 
-### Distributed Search
+#### Distributed Search
 
 Search can be performed with multiple workers using the `MPI` / `torch.distributed` library. To use this functionality, your script should be called with `mpirun`/`mpiexec` command and an additional `--distributed` param has to be set (`DyNAS([...], distributed=True`).
 
@@ -230,5 +229,4 @@ OMP_NUM_THREADS=28 mpirun \
 ## Legal Disclaimer and Notices
 
 > This “research quality code”  is for Non-Commercial purposes provided by Intel “As Is” without any express or implied warranty of any kind. Please see the dataset's applicable license for terms and conditions. Intel does not own the rights to this data set and does not confer any rights to it. Intel does not warrant or assume responsibility for the accuracy or completeness of any information, text, graphics, links or other items within the code. A thorough security review has not been performed on this code. Additionally, this repository may contain components that are out of date or contain known security vulnerabilities.
-
 > ImageNet, WMT, SST2: Please see the dataset's applicable license for terms and conditions. Intel does not own the rights to this data set and does not confer any rights to it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
-Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
+
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation.
 
 ## Reporting a Vulnerability
+
 Please report any security vulnerabilities in this project [utilizing the guidelines here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,7 @@ flake8-html
 flake8
 isort
 mypy
+pymarkdownlnt
 pytest-cov
 pytest
 tox

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,7 @@ flake8-html
 flake8
 isort
 mypy
-pymarkdownlnt
+pymarkdownlnt; python_version >= '3.8'
 pytest-cov
 pytest
 tox


### PR DESCRIPTION
To keep Markdown files consistent and clean a new check is being added to the CI.

This check is based on the `pymarkdownlnt` library and any issues will result in validation failure of the PR.