### PR TITLE
Fix verification method for measurement types

### DIFF
--- a/dynast/supernetwork/supernetwork_registry.py
+++ b/dynast/supernetwork/supernetwork_registry.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Dict, List
+from typing import List
 
 from dynast.supernetwork.image_classification.bootstrapnas.bootstrapnas_encoding import BootstrapNASEncoding
 from dynast.supernetwork.image_classification.bootstrapnas.bootstrapnas_interface import EvaluationInterfaceBootstrapNAS

--- a/dynast/utils/exceptions.py
+++ b/dynast/utils/exceptions.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from dynast.supernetwork.supernetwork_registry import SUPERNET_METRICS, SUPERNET_PARAMETERS
 
 

--- a/dynast/utils/exceptions.py
+++ b/dynast/utils/exceptions.py
@@ -1,0 +1,16 @@
+from dynast.supernetwork.supernetwork_registry import SUPERNET_METRICS, SUPERNET_PARAMETERS
+
+
+class InvalidSupernetException(Exception):
+    def __init__(self, supernet):
+        self.message = f'Invalid super-network ({supernet}) specified. Choose from the following: {list(SUPERNET_PARAMETERS.keys())}'
+        super().__init__(self.message)
+
+
+class InvalidMetricsException(Exception):
+    def __init__(self, supernet, metric):
+        valid_metrics = SUPERNET_METRICS[supernet]
+        self.message = (
+            f'Invalid metric specified: {metric}. Super-network f{supernet} supports following metrics: {valid_metrics}'
+        )
+        super().__init__(self.message)

--- a/tests/search/test_search_tactic.py
+++ b/tests/search/test_search_tactic.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import pytest
 
 from dynast.search.search_tactic import NASBaseConfig

--- a/tests/search/test_search_tactic.py
+++ b/tests/search/test_search_tactic.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dynast.search.search_tactic import NASBaseConfig
+from dynast.utils.exceptions import InvalidMetricsException, InvalidSupernetException
+
+
+class TestNASBaseConfig:
+    def test_verify_measurement_types_all_valid(self):
+        nbc = NASBaseConfig(
+            supernet='ofa_mbv3_d234_e346_k357_w1.0',
+            optimization_metrics=['latency', 'accuracy_top1'],
+            measurements=['latency', 'macs', 'params', 'accuracy_top1'],
+        )
+        assert list(sorted(nbc.measurements)) == list(sorted(['latency', 'macs', 'params', 'accuracy_top1']))
+        assert list(sorted(nbc.optimization_metrics)) == list(sorted(['latency', 'accuracy_top1']))
+
+    def test_verify_measurement_types_invalid_optimization_metric_raises_exception(self):
+        with pytest.raises(InvalidMetricsException):
+            nbc = NASBaseConfig(
+                supernet='ofa_mbv3_d234_e346_k357_w1.0',
+                optimization_metrics=['fake_metric', 'accuracy_top1'],
+                measurements=['latency', 'macs', 'params', 'accuracy_top1'],
+            )
+
+    def test_verify_measurement_types_invalid_measurements_raises_exception(self):
+        with pytest.raises(InvalidMetricsException):
+            nbc = NASBaseConfig(
+                supernet='ofa_mbv3_d234_e346_k357_w1.0',
+                optimization_metrics=['latency', 'accuracy_top1'],
+                measurements=['fake_metric', 'macs', 'params', 'accuracy_top1'],
+            )
+
+    def test_verify_measurement_types_invalid_supernet(self):
+        with pytest.raises(InvalidSupernetException):
+            nbc = NASBaseConfig(
+                supernet='fake_supernet',
+                optimization_metrics=['latency', 'accuracy_top1'],
+                measurements=['latency', 'macs', 'params', 'accuracy_top1'],
+            )

--- a/tests/test_dynast_manager.py
+++ b/tests/test_dynast_manager.py
@@ -48,8 +48,8 @@ def test_dynas_supported_search_tactics():
     assert isinstance(
         DyNAS(
             supernet='ofa_resnet50',
-            optimization_metrics=['m1', 'm2', 'm3'],
-            measurements=['m1', 'm2', 'm3'],
+            optimization_metrics=['latency', 'macs'],
+            measurements=['latency', 'macs'],
             search_tactic='linas',
             num_evals=1,
             results_path='test',
@@ -61,8 +61,8 @@ def test_dynas_supported_search_tactics():
     assert isinstance(
         DyNAS(
             supernet='ofa_resnet50',
-            optimization_metrics=['m1', 'm2', 'm3'],
-            measurements=['m1', 'm2', 'm3'],
+            optimization_metrics=['latency', 'macs'],
+            measurements=['latency', 'macs'],
             search_tactic='evolutionary',
             num_evals=1,
             results_path='test',
@@ -74,8 +74,8 @@ def test_dynas_supported_search_tactics():
     assert isinstance(
         DyNAS(
             supernet='ofa_resnet50',
-            optimization_metrics=['m1', 'm2', 'm3'],
-            measurements=['m1', 'm2', 'm3'],
+            optimization_metrics=['latency', 'macs'],
+            measurements=['latency', 'macs'],
             search_tactic='random',
             num_evals=1,
             results_path='test',
@@ -87,8 +87,8 @@ def test_dynas_supported_search_tactics():
     assert isinstance(
         DyNAS(
             supernet='ofa_resnet50',
-            optimization_metrics=['m1', 'm2', 'm3'],
-            measurements=['m1', 'm2', 'm3'],
+            optimization_metrics=['latency', 'macs'],
+            measurements=['latency', 'macs'],
             search_tactic='linas',
             distributed=True,
             num_evals=1,
@@ -101,8 +101,8 @@ def test_dynas_supported_search_tactics():
     assert isinstance(
         DyNAS(
             supernet='ofa_resnet50',
-            optimization_metrics=['m1', 'm2', 'm3'],
-            measurements=['m1', 'm2', 'm3'],
+            optimization_metrics=['latency', 'macs'],
+            measurements=['latency', 'macs'],
             search_tactic='random',
             distributed=True,
             num_evals=1,


### PR DESCRIPTION
`NASBaseConfig.verify_measurement_types` relied on hardcoded super-network types to validate specified measurement and optimization metric types. This PR modifies the method to remove hardcoded values and cross check supported measurements against the list stored in super-network registry.