### PR TITLE
Auto-fetch Search Metrics in CLI from Supernetwork Registry

### DIFF
--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -15,6 +15,7 @@
 import argparse
 
 from dynast import DyNAS
+from dynast.supernetwork.supernetwork_registry import get_all_supported_metrics, get_supported_supernets
 
 
 def _main(args):
@@ -51,33 +52,23 @@ def main():
         default='ofa_mbv3_d234_e346_k357_w1.0',
         type=str,
         help='Super-network',
-        choices=[
-            'ofa_resnet50',
-            'ofa_mbv3_d234_e346_k357_w1.0',
-            'ofa_mbv3_d234_e346_k357_w1.2',
-            'ofa_proxyless_d234_e346_k357_w1.3',
-            'transformer_lt_wmt_en_de',
-            'bert_base_sst2',
-            'vit_base_imagenet',
-            'inc_quantization_ofa_resnet50',
-        ],
+        choices=get_supported_supernets(),
     )
     parser.add_argument('--seed', default=42, type=int, help='Random Seed')
-    # TODO(macsz) might be better to list allowed elements here (or in help message)
     parser.add_argument(
         '--optimization_metrics',
-        default=['accuracy_top1', 'macs'],  # TODO*macsz) Consider just 'accuracy',
-        # as it translates better for both image classification
-        # and Transformer LT
+        default=['accuracy_top1', 'macs'],
         nargs='*',
         type=str,
-        help='Metrics that will be optimized for during search.',
+        choices=get_all_supported_metrics(),
+        help='Metrics that will be used to guide the search towards Pareto-optimal front of network configurations.',
     )
     parser.add_argument(
         '--measurements',
-        default=['accuracy_top1', 'macs', 'params', 'latency'],  # TODO(macsz) Ditto
+        default=['accuracy_top1', 'macs', 'params', 'latency'],
         nargs='*',
         type=str,
+        choices=get_all_supported_metrics(),
         help='Measurements during search.',
     )
     parser.add_argument('-d', '--device', default='cpu', type=str, help='Target device to run measurements on.')

--- a/dynast/supernetwork/supernetwork_registry.py
+++ b/dynast/supernetwork/supernetwork_registry.py
@@ -204,3 +204,11 @@ def get_csv_header(supernet: str) -> List[str]:
         raise Exception('Cound not detect supernet type. Please check supernetwork\'s registry.')
 
     return csv_header
+
+
+def get_supported_supernets():
+    return list(EVALUATION_INTERFACE.keys())
+
+
+def get_all_supported_metrics():
+    return list(set([metric for metrics in SUPERNET_METRICS.values() for metric in metrics]))

--- a/tests/supernetwork/test_supernetwork_registry.py
+++ b/tests/supernetwork/test_supernetwork_registry.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from dynast.supernetwork.supernetwork_registry import (
+    EVALUATION_INTERFACE,
+    SUPERNET_METRICS,
+    get_all_supported_metrics,
+    get_supported_supernets,
+)
+
+
+def test_get_supported_supernets():
+    assert get_supported_supernets() == list(EVALUATION_INTERFACE.keys())
+
+
+def test_get_all_supported_metrics():
+    metrics = []
+    for s, ms in SUPERNET_METRICS.items():
+        metrics.extend(ms)
+    unique_metrics = list(set(metrics))
+    assert unique_metrics == get_all_supported_metrics()


### PR DESCRIPTION
Previously, metrics guiding the search process within the CLI interface were hardcoded. This led to manual updates in multiple locations each time a new supernetwork was introduced.

With this commit, the CLI interface will now automatically fetch possible metrics directly from the supernetwork registry, streamlining the integration of new supernetworks and reducing redundancy.