### PR TITLE
Fix communication timeout in distributed search

### DIFF
--- a/dynast/cli.py
+++ b/dynast/cli.py
@@ -38,6 +38,7 @@ def _main(args):
         test_fraction=args.test_fraction,
         dataloader_workers=args.dataloader_workers,
         distributed=args.distributed,
+        dist_timeout=args.dist_timeout,
     )
 
     results = agent.search()
@@ -121,7 +122,17 @@ def main():
         help='If set, a distributed implementation of the search algorithm will be used.',
     )
     dist_parser.add_argument(
-        "--local_rank", type=int, help="Local rank. Necessary for using the torch.distributed.launch utility."
+        "--local_rank",
+        type=int,
+        help="Local rank. Necessary for using the torch.distributed.launch utility. Do not set manually.",
+    )
+    dist_parser.add_argument(
+        "--dist_timeout",
+        type=int,
+        default=3600,
+        help="Timeout for the distributed search in seconds. This timeout is for communication between workers, "
+        "not the total search time (time between workers that were first and last to finish evaluating assigned "
+        "configurations within a single population).",
     )
     dist_parser.add_argument("--backend", type=str, default="gloo", choices=['gloo'])
 

--- a/dynast/dynast_manager.py
+++ b/dynast/dynast_manager.py
@@ -60,7 +60,8 @@ class DyNAS:
         LOCAL_RANK, WORLD_RANK, WORLD_SIZE, DIST_METHOD = get_distributed_vars()
         if DIST_METHOD:
             backend = kwargs.get('backend', 'gloo')
-            init_distributed(backend, WORLD_RANK, WORLD_SIZE)
+            dist_timeout = kwargs.get('dist_timeout', 3600)
+            init_distributed(backend, WORLD_RANK, WORLD_SIZE, dist_timeout)
             seed = kwargs.get('seed', None)
             if seed:
                 kwargs['seed'] = seed + WORLD_RANK

--- a/dynast/utils/distributed.py
+++ b/dynast/utils/distributed.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from datetime import timedelta
 from pathlib import PosixPath
 from typing import Tuple
 
@@ -43,8 +44,8 @@ def get_distributed_vars() -> Tuple[int, int, int, str]:
     return local_rank, world_rank, world_size, dist_method
 
 
-def init_distributed(backend: str, world_rank: int, world_size: int) -> None:
-    dist.init_process_group(backend, rank=world_rank, world_size=world_size)
+def init_distributed(backend: str, world_rank: int, world_size: int, dist_timeout: int = 3600) -> None:
+    dist.init_process_group(backend, rank=world_rank, world_size=world_size, timeout=timedelta(seconds=dist_timeout))
 
 
 def is_main_process() -> bool:


### PR DESCRIPTION
With default MPI/Gloo communication timeout (30m) for certain type of optimization metrics there is a chance for the time between workers that were first and last to finish evaluating assigned configurations within a single population to cause a communication timeout. Increasing this limit prevents this issue.