### PR TITLE
Clear main result file when distributed search is started.

### DIFF
--- a/dynast/search/search_tactic.py
+++ b/dynast/search/search_tactic.py
@@ -789,6 +789,9 @@ class LINASDistributed(LINAS):
         LOCAL_RANK, WORLD_RANK, WORLD_SIZE, DIST_METHOD = get_distributed_vars()
         results_path = get_worker_results_path(results_path, WORLD_RANK)
 
+        if is_main_process() and os.path.exists(self.main_results_path):
+            os.remove(self.main_results_path)
+
         if 'cuda' in device:
             device = f'cuda:{LOCAL_RANK}'
             log.info(f'Setting device to {device}')
@@ -1098,6 +1101,10 @@ class RandomSearchDistributed(RandomSearch):
     ):
         self.main_results_path = results_path
         LOCAL_RANK, WORLD_RANK, WORLD_SIZE, DIST_METHOD = get_distributed_vars()
+
+        if is_main_process() and os.path.exists(self.main_results_path):
+            os.remove(self.main_results_path)
+
         results_path = get_worker_results_path(results_path, WORLD_RANK)
 
         if 'cuda' in device:

--- a/dynast/utils/distributed.py
+++ b/dynast/utils/distributed.py
@@ -49,13 +49,21 @@ def init_distributed(backend: str, world_rank: int, world_size: int, dist_timeou
 
 
 def is_main_process() -> bool:
+    """Return True if current process is main process in a distributed environment.
+
+    Note: returns True if not running in distributed mode.
+    """
     _, world_rank, _, _ = get_distributed_vars()
     if world_rank is None:
-        raise Exception('Not running in distributed mode.')
+        return True
     return world_rank == 0
 
 
 def is_worker_process() -> bool:
+    """Return True if current process is a worker process in a distributed environment.
+
+    Note: returns False if not running in distributed mode.
+    """
     _, world_rank, _, _ = get_distributed_vars()
     if world_rank is None:
         raise Exception('Not running in distributed mode.')

--- a/tests/utils/test_distributed.py
+++ b/tests/utils/test_distributed.py
@@ -59,8 +59,7 @@ def test_is_main_process() -> None:
     ):
         assert not is_main_process()
 
-    with pytest.raises(Exception):
-        is_main_process()
+    assert is_main_process()
 
 
 def test_is_worker_process() -> None:


### PR DESCRIPTION
Previously only worker's result files were cleared on every search, with the main being carried over from the last search experiment (if the --result_path value was the same between the two runs). This change fixes this.