### PR TITLE
Reset logs for 3rd party libraries

### DIFF
--- a/dynast/supernetwork/image_classification/ofa_quantization/inc_quantization.py
+++ b/dynast/supernetwork/image_classification/ofa_quantization/inc_quantization.py
@@ -22,6 +22,8 @@ import torch
 import yaml
 from neural_compressor.experimental import Quantization
 
+from dynast.utils import reset_logger
+
 
 def default_policy() -> dict:
     policy = {
@@ -237,6 +239,10 @@ def inc_quantize(
     Return:
         model_qt: quantized model
     '''
+
+    # Set INC logger level to ERROR to limit INC's verbosity (prints network architecture to INFO by default).
+    reset_logger()
+
     model_fp.eval()
 
     if mp_calibration_samples is not None:

--- a/dynast/utils/__init__.py
+++ b/dynast/utils/__init__.py
@@ -19,7 +19,7 @@ import logging
 import os
 import subprocess
 import time as _time
-from typing import List, Union
+from typing import List
 
 import pandas as pd
 import requests

--- a/dynast/utils/__init__.py
+++ b/dynast/utils/__init__.py
@@ -19,7 +19,7 @@ import logging
 import os
 import subprocess
 import time as _time
-from typing import List
+from typing import List, Union
 
 import pandas as pd
 import requests
@@ -30,7 +30,7 @@ from dynast.utils.distributed import get_distributed_vars
 def set_logger(
     level: int = logging.INFO,
     auxiliary_log_level: int = logging.ERROR,
-):
+) -> None:
     """Create logger object and set the logging level to `level`."""
     global log
     log = logging.getLogger()
@@ -52,13 +52,25 @@ def set_logger(
     console_handler.setFormatter(formatter)
     log.addHandler(console_handler)
 
-    # Disable PIL polluting logs with it's debug logs: https://github.com/camptocamp/pytest-odoo/issues/15
-    logging.getLogger('PIL').setLevel(auxiliary_log_level)
-    logging.getLogger('fvcore.nn.jit_analysis').setLevel(auxiliary_log_level)
+    # PIL pollutes logs with debug by default: https://github.com/camptocamp/pytest-odoo/issues/15
+    loggers_3rd_party = ['PIL', 'fvcore.nn.jit_analysis', 'neural_compressor']
+    for logger_3rd_party in loggers_3rd_party:
+        logging.getLogger(logger_3rd_party).setLevel(auxiliary_log_level)
 
 
-log = None
+log: Union[logging.Logger, None] = None
+
 set_logger()
+
+
+def reset_logger() -> None:
+    """Resets logger settings. Useful when 3rd party logger is created after DyNAS-T logger and overwrites it's settings."""
+    global log
+    if not log:
+        # To avoid crashes if logger hasn't been initialized yet, initialize it with default settings
+        set_logger()
+        return
+    set_logger(level=log.level)
 
 
 def measure_time(func):

--- a/dynast/utils/__init__.py
+++ b/dynast/utils/__init__.py
@@ -58,7 +58,7 @@ def set_logger(
         logging.getLogger(logger_3rd_party).setLevel(auxiliary_log_level)
 
 
-log: Union[logging.Logger, None] = None
+log = None
 
 set_logger()
 


### PR DESCRIPTION
In some cases 3rd party library might be setting logger level after DyNAS-T's own logger is already initialized and overwrite it's settings. This PR adds method to reset log levels after initialization. This new method `reset_logger` has to be called each time after a library that overwrites logger settings is called.