### PR TITLE
Fix RunManager device setting in OFA

### DIFF
--- a/dynast/supernetwork/image_classification/ofa/ofa_interface.py
+++ b/dynast/supernetwork/image_classification/ofa/ofa_interface.py
@@ -117,6 +117,7 @@ class OFARunner:
             self.run_config,
             init=False,
             verbose=self.verbose,
+            no_gpu=False if 'cuda' in self.device else True,
         )
         run_manager.reset_running_statistics(net=subnet)
 

--- a/dynast/supernetwork/image_classification/ofa_quantization/quantization_interface.py
+++ b/dynast/supernetwork/image_classification/ofa_quantization/quantization_interface.py
@@ -189,6 +189,7 @@ class QuantizedOFARunner:
             self.run_config,
             init=False,
             verbose=self.verbose,
+            no_gpu=False if 'cuda' in self.device else True,
         )
         run_manager.reset_running_statistics(net=subnet)
 


### PR DESCRIPTION
If ran with `device='cpu'` on a machine with GPU available, OFA would force `RunManager` to use GPU. This PR fixes this issue.