### PR TITLE
Update Transformers to 4.37

### DIFF
--- a/dynast/supernetwork/image_classification/ofa_quantization/inc_quantization.py
+++ b/dynast/supernetwork/image_classification/ofa_quantization/inc_quantization.py
@@ -115,22 +115,26 @@ def qconfig_parse(
     a_observer, a_dtype, a_scheme, a_granularity = qparam_parse(aobserver_type, abit, amode, agranularity)
 
     qconfig = {
-        'weight': {
-            'algorithm': [w_observer],
-            'dtype': [w_dtype],
-            'scheme': [w_scheme],
-            'granularity': [w_granularity],
-        }
-        if w_dtype != 'fp32'
-        else {'dtype': ['fp32']},
-        'activation': {
-            'algorithm': [a_observer],
-            'dtype': [a_dtype],
-            'scheme': [a_scheme],
-            'granularity': [a_granularity],
-        }
-        if a_dtype != 'fp32'
-        else {'dtype': ['fp32']},
+        'weight': (
+            {
+                'algorithm': [w_observer],
+                'dtype': [w_dtype],
+                'scheme': [w_scheme],
+                'granularity': [w_granularity],
+            }
+            if w_dtype != 'fp32'
+            else {'dtype': ['fp32']}
+        ),
+        'activation': (
+            {
+                'algorithm': [a_observer],
+                'dtype': [a_dtype],
+                'scheme': [a_scheme],
+                'granularity': [a_granularity],
+            }
+            if a_dtype != 'fp32'
+            else {'dtype': ['fp32']}
+        ),
     }
 
     return qconfig

--- a/dynast/supernetwork/text_classification/bert_interface.py
+++ b/dynast/supernetwork/text_classification/bert_interface.py
@@ -39,7 +39,7 @@ def load_supernet(checkpoint_path):
     model = BertSupernetForSequenceClassification(bert_config, num_labels=2)
     model.load_state_dict(
         torch.load(checkpoint_path, map_location='cpu')["model"],
-        strict=True,
+        strict=False,
     )
     return model, bert_config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ scipy>=1.7.3
 torch>=1.12.0
 torchprofile>=0.0.4
 torchvision>=0.13.0
-transformers>=4.10.0,<=4.27.1
+transformers>=4.10.0,<=4.37.2


### PR DESCRIPTION
Older version (pre 4.36) contain several security vulnerabilities.

However, not all Transformer-based supernets are compatible with `transformers>4.27.1`. In most cases it is enough to simply set `strict=False` when loading the model.